### PR TITLE
Добавляет возможность публикации на GitHub Pages

### DIFF
--- a/.github/workflows/deploy-ghp.yml
+++ b/.github/workflows/deploy-ghp.yml
@@ -3,7 +3,7 @@ name: Публикация сайта на GitHub Pages
 on:
   push:
     branches:
-      - feature/publishing-github-pages
+      - main
 
 jobs:
   deploy:
@@ -25,8 +25,7 @@ jobs:
       - name: Установка модулей
         run: npm ci
       - name: Сборка сайта
-        run: |
-          npm run build
+        run: npm run build
       - name: Публикация сайта
         uses: JamesIves/github-pages-deploy-action@4.1.1
         with:

--- a/.github/workflows/deploy-ghp.yml
+++ b/.github/workflows/deploy-ghp.yml
@@ -1,0 +1,34 @@
+name: Публикация сайта на GitHub Pages
+
+on:
+  push:
+    branches:
+      - feature/publishing-github-pages
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Загрузка из репозитория
+        uses: actions/checkout@v2
+      - name: Кэширование модулей
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Установка модулей
+        run: npm ci
+      - name: Сборка сайта
+        run: |
+          npm run build
+      - name: Публикация сайта
+        uses: JamesIves/github-pages-deploy-action@4.1.1
+        with:
+          branch: preview
+          folder: _site


### PR DESCRIPTION
С помощью этого GitHub Action будет публиковаться сайт. Модули кэшируются, чтобы публикация занимала меньше времени. Используется [специальный Action](https://github.com/JamesIves/github-pages-deploy-action), чтобы публиковать новую версию сайта. Сам сайт доступен [здесь](https://physcodestyle.github.io/algo-doc/).

Перед слиянием необходимо поменять триггер для GitHub Action.

Этот пиар связан с [другим](https://github.com/physcodestyle/algo-doc/pull/35).